### PR TITLE
feat: add az:// (Azure Blob Storage) as recognized remote URL scheme

### DIFF
--- a/cmd/bd/config.go
+++ b/cmd/bd/config.go
@@ -406,7 +406,7 @@ var configValidateCmd = &cobra.Command{
 Checks:
   - federation.sovereignty is valid (T1, T2, T3, T4, or empty)
   - federation.remote is set for Dolt sync
-  - Remote URL format is valid (dolthub://, gs://, s3://, file://)
+  - Remote URL format is valid (dolthub://, gs://, s3://, az://, file://)
   - routing.mode is valid (auto, maintainer, contributor, explicit)
 
 Examples:
@@ -499,7 +499,7 @@ func validateSyncConfig(repoPath string) []string {
 	// Validate remote URL format
 	if federationRemote != "" {
 		if !isValidRemoteURL(federationRemote) {
-			issues = append(issues, fmt.Sprintf("federation.remote: %q is not a valid remote URL (expected dolthub://, gs://, s3://, file://, or standard git URL)", federationRemote))
+			issues = append(issues, fmt.Sprintf("federation.remote: %q is not a valid remote URL (expected dolthub://, gs://, s3://, az://, file://, or standard git URL)", federationRemote))
 		}
 	}
 

--- a/cmd/bd/dolt.go
+++ b/cmd/bd/dolt.go
@@ -222,6 +222,7 @@ uncommitted changes in its working set).`,
 					fmt.Fprintln(os.Stderr, "Supported remote URLs:")
 					fmt.Fprintln(os.Stderr, "  • GitHub (via git):   git+ssh://git@github.com/org/repo.git")
 					fmt.Fprintln(os.Stderr, "  • DoltHub:            https://doltremoteapi.dolthub.com/org/repo")
+					fmt.Fprintln(os.Stderr, "  • Azure Blob Storage: az://account.blob.core.windows.net/container/path")
 				} else if isDivergedHistoryErr(err) {
 					printDivergedHistoryGuidance("push --force")
 				}
@@ -244,6 +245,7 @@ uncommitted changes in its working set).`,
 					fmt.Fprintln(os.Stderr, "Supported remote URLs:")
 					fmt.Fprintln(os.Stderr, "  • GitHub (via git):   git+ssh://git@github.com/org/repo.git")
 					fmt.Fprintln(os.Stderr, "  • DoltHub:            https://doltremoteapi.dolthub.com/org/repo")
+					fmt.Fprintln(os.Stderr, "  • Azure Blob Storage: az://account.blob.core.windows.net/container/path")
 				} else if isDivergedHistoryErr(err) {
 					printDivergedHistoryGuidance("push")
 				}

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -159,7 +159,7 @@ Control when sync operations occur:
 
 #### Federation Configuration
 
-- `federation.remote`: Dolt remote URL (e.g., `dolthub://org/beads`, `gs://bucket/beads`, `s3://bucket/beads`)
+- `federation.remote`: Dolt remote URL (e.g., `dolthub://org/beads`, `gs://bucket/beads`, `s3://bucket/beads`, `az://account.blob.core.windows.net/container/beads`)
 - `federation.sovereignty`: Data sovereignty tier:
   - `T1`: Full sovereignty - data never leaves controlled infrastructure
   - `T2`: Regional sovereignty - data stays within region/jurisdiction

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -144,7 +144,7 @@ func Initialize() error {
 	v.SetDefault("sync.require_confirmation_on_mass_delete", false)
 
 	// Federation configuration (optional Dolt remote)
-	v.SetDefault("federation.remote", "")      // e.g., dolthub://org/beads, gs://bucket/beads, s3://bucket/beads
+	v.SetDefault("federation.remote", "")      // e.g., dolthub://org/beads, gs://bucket/beads, s3://bucket/beads, az://account.blob.core.windows.net/container/beads
 	v.SetDefault("federation.sovereignty", "") // T1 | T2 | T3 | T4 (empty = no restriction)
 
 	// Push configuration defaults

--- a/internal/remotecache/url.go
+++ b/internal/remotecache/url.go
@@ -12,6 +12,7 @@ var remoteSchemes = []string{
 	"dolthub://",
 	"gs://",
 	"s3://",
+	"az://",
 	"file://",
 	"https://",
 	"http://",
@@ -25,7 +26,7 @@ var gitSSHPattern = regexp.MustCompile(`^[a-zA-Z0-9._-]+@[a-zA-Z0-9][a-zA-Z0-9._
 
 // IsRemoteURL returns true if s looks like a dolt remote URL rather than
 // a local filesystem path. Recognized schemes: dolthub://, https://, http://,
-// s3://, gs://, file://, ssh://, git+ssh://, git+https://, and SCP-style
+// s3://, gs://, az://, file://, ssh://, git+ssh://, git+https://, and SCP-style
 // git@host:path.
 func IsRemoteURL(s string) bool {
 	for _, scheme := range remoteSchemes {

--- a/internal/remotecache/url_test.go
+++ b/internal/remotecache/url_test.go
@@ -16,6 +16,7 @@ func TestIsRemoteURL(t *testing.T) {
 		{"http://localhost:50051/mydb", true},
 		{"s3://my-bucket/beads", true},
 		{"gs://my-bucket/beads", true},
+		{"az://account.blob.core.windows.net/container/beads", true},
 		{"file:///tmp/dolt-remote", true},
 		{"ssh://git@github.com/org/repo", true},
 		{"git+ssh://git@github.com/org/repo", true},


### PR DESCRIPTION
Add az:// as a recognized Dolt remote URL scheme and fix CLI directory resolution for drift/apply remote checks.